### PR TITLE
fix: use HTTP_PORT instead of PORT in the schema in env.js

### DIFF
--- a/plugins/env.js
+++ b/plugins/env.js
@@ -5,7 +5,7 @@ export default async function configPlugin(server, options, done) {
     type: "object",
     required: ["HTTP_PORT"],
     properties: {
-      PORT: {
+      HTTP_PORT: {
         type: "number",
         default: 3001,
       },


### PR DESCRIPTION
Fixes the env var name in the schema.